### PR TITLE
TASK: Add 'toOriginalRequest' option to redirect->afterLogin setting

### DIFF
--- a/Classes/Sandstorm/UserManagement/Domain/Service/Flow/FlowRedirectTargetService.php
+++ b/Classes/Sandstorm/UserManagement/Domain/Service/Flow/FlowRedirectTargetService.php
@@ -29,6 +29,15 @@ class FlowRedirectTargetService implements RedirectTargetServiceInterface
     public function onAuthenticationSuccess(ControllerContext $controllerContext, ActionRequest $originalRequest = null)
     {
         if (is_array($this->redirectAfterLogin)
+            && array_key_exists('toOriginalRequest', $this->redirectAfterLogin)
+            && $this->redirectAfterLogin['toOriginalRequest'] === true
+            && $originalRequest !== null
+        ) {
+            // If an original request is stored, redirect there!
+            return $originalRequest;
+        }
+
+        if (is_array($this->redirectAfterLogin)
             && array_key_exists('action', $this->redirectAfterLogin)
             && array_key_exists('controller', $this->redirectAfterLogin)
             && array_key_exists('package', $this->redirectAfterLogin)

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -30,8 +30,10 @@ Sandstorm:
     redirect:
       afterLogin: []
       afterLogout: []
-    # To activate redirection, make these settings. controllerArguments are optional.
+    # To activate redirection, make these settings. controllerArguments are optional. For "afterLogin", either "action / controller / package" or
+    # "toOriginalRequest" are mandatory.
 #      afterLogin:
+#        toOriginalRequest: false           # set to TRUE if you want to redirect to the original request.
 #        action: 'action'
 #        controller: 'Controller'
 #        package: 'Your.Package'

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Sandstorm:
     redirect:
     # To activate redirection, make these settings:
       afterLogin:
+        toOriginalRequest: false
         action: 'action'
         controller: 'Controller'
         package: 'Your.Package'
@@ -168,6 +169,9 @@ Sandstorm:
         controller: 'Controller'
         package: 'Your.Package'
 ```
+
+Set `toOriginalRequest` to `true` if you want to redirect to the original request after a successful login.
+When no original request is present the `toOriginalRequest` setting will be ignored.
 
 ### Via node properties
 When using the package within Neos, you have another possibility: you can set properties on the LoginForm node type.


### PR DESCRIPTION
* If set to **true** and an **original request** is present: redirect to that request after successful login.
* If set to **true** and **no original request** is present: this option will be ignored
* If set to **false**: this option will be ignored