### PR TITLE
[BUGFIX] Add missing provider for Neos.Neos:Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Neos:
       authentication:
         providers:
           'Neos.Neos:Backend':
+            provider: PersistedUsernamePasswordProvider
             requestPatterns:
               Sandstorm.UserManagement:NeosBackend:
                 pattern: Sandstorm\UserManagement\Security\NeosRequestPattern


### PR DESCRIPTION
Without the provider the cli command `./flow sandstormuser:create test@example.com password --additionalAttributes="firstName:Max;lastName:Mustermann"` produces the following error:

```
The configured authentication provider "Neos.Neos:Backend" needs a "provider" option!
Type: Neos\Flow\Security\Exception\InvalidAuthenticationProviderException
  Code: 1248209521
  File:
Data/Temporary/Production/Cache/Code/Flow_Object_Classes/Neos_Flow_Security
        _Authentication_AuthenticationProviderManager.php
  Line: 299

Open Data/Logs/Exceptions/20170629064240c61469.txt for a full stack
trace.

  Type: Neos\Flow\Core\Booting\Exception\SubProcessException
  Code: 1355480641
  File: Packages/Framework/Neos.Flow/Classes/Core/Booting/Scripts.php
  Line: 611
```

neos/flow: 4.1.2
sandstorm/usermanagement: 5.0.6