### PR TITLE
Remove obsolete usage of party repository

### DIFF
--- a/Classes/Controller/ProfileController.php
+++ b/Classes/Controller/ProfileController.php
@@ -2,14 +2,14 @@
 namespace Sandstorm\UserManagement\Controller;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Security\Account;
-use Neos\Flow\Security\Context;
 use Neos\Flow\Security\AccountRepository;
 use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Authentication\Token\UsernamePassword;
 use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Cryptography\HashService;
-use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Party\Domain\Repository\PartyRepository;
 use Sandstorm\UserManagement\Domain\Model\User;
 use Sandstorm\UserManagement\Domain\Repository\UserRepository;
@@ -24,12 +24,6 @@ class ProfileController extends ActionController
      * @Flow\Inject
      */
     protected $securityContext;
-
-    /**
-     * @var PartyRepository
-     * @Flow\Inject
-     */
-    protected $partyRepository;
 
     /**
      * @var UserRepository


### PR DESCRIPTION
This change removes a property referring to the party repository which
is not used anyway and requires the Party package to be installed
(which is not declared as a dependency in composer.json).