### PR TITLE
BUGFIX: send response and exit in redirectToUriAndShutdown

### DIFF
--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -171,7 +171,9 @@ class LoginController extends AbstractAuthenticationController
         $response->setHeader('Status', '303');
 
         $response->setContent('<html><head><meta http-equiv="refresh" content="0;url=' . $escapedUri . '"/></head></html>');
+        $response->send();
 
         $this->bootstrap->shutdown(Bootstrap::RUNLEVEL_RUNTIME);
+        exit();
     }
 }


### PR DESCRIPTION
Send response in `redirectToUriAndShutdown` and exit properly from function. Redirect was not working correctly before and Flow therefore trying to load a (potentially not existing) `Logout` template.