### PR TITLE
TASK: Add Neos 5.x Compatibility

### DIFF
--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -2,6 +2,7 @@
 namespace Sandstorm\UserManagement\Controller;
 
 use Neos\Error\Messages\Error;
+use Neos\Error\Messages\Message;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Sandstorm\UserManagement\Domain\Service\RedirectTargetServiceInterface;
@@ -9,8 +10,9 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Exception;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController;
-use Neos\Flow\Mvc\FlashMessage\FlashMessageContainer;
 use Neos\Flow\Core\Bootstrap;
+use Psr\Http\Message\UriFactoryInterface;
+
 
 class LoginController extends AbstractAuthenticationController
 {
@@ -40,11 +42,6 @@ class LoginController extends AbstractAuthenticationController
      * @Flow\InjectConfiguration(path="authFailedMessage.body")
      */
     protected $loginFailedBody;
-
-    /**
-     * @var FlashMessageContainer
-     */
-    protected $flashMessageContainer;
 
     /**
      * SkipCsrfProtection is needed here because we will have errors otherwise if we render multiple
@@ -98,12 +95,7 @@ class LoginController extends AbstractAuthenticationController
     protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
     {
         $this->emitAuthenticationFailure($this->controllerContext, $exception);
-
-        $this->flashMessageContainer = new FlashMessageContainer();
-
-        //TODO: This does not work yet. There is no error but it will not be displayed.
-        $this->flashMessageContainer->addMessage(new Error($this->loginFailedBody,
-            ($exception === null ? 1347016771 : $exception->getCode()), [], $this->loginFailedTitle));
+        $this->addFlashMessage($this->loginFailedBody, $this->loginFailedTitle,Message::SEVERITY_ERROR, [], ($exception === null ? 1347016771 : $exception->getCode()));
     }
 
     /**

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -10,7 +10,6 @@ use Neos\Flow\Exception;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController;
 use Neos\Flow\Mvc\FlashMessage\FlashMessageContainer;
-
 use Neos\Flow\Core\Bootstrap;
 
 class LoginController extends AbstractAuthenticationController
@@ -173,18 +172,7 @@ class LoginController extends AbstractAuthenticationController
     protected function redirectToUriAndShutdown(string $result)
     {
         $escapedUri = htmlentities($result, ENT_QUOTES, 'utf-8');
-
-
-        //TODO: Switch to ActionRequest. This does not work anymore.
-        $response = $this->bootstrap->getActiveRequestHandler()->getHttpResponse(); /** @var  \Neos\Flow\Http\Response $response*/
-
-        //TODO: When switched to ActionRequest then you can make this in one line with ->setRedirectUri()
-        $response->setHeader('Location', $escapedUri);
-        $response->setHeader('Status', '303');
-
-        $response->setContent('<html><head><meta http-equiv="refresh" content="0;url=' . $escapedUri . '"/></head></html>');
-        $response->send();
-
+        $this->redirectToUri($this->uriFactory->createUri((string)$escapedUri));
         $this->bootstrap->shutdown(Bootstrap::RUNLEVEL_RUNTIME);
         exit();
     }

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -9,6 +9,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Exception;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Authentication\Controller\AbstractAuthenticationController;
+use Neos\Flow\Mvc\FlashMessage\FlashMessageContainer;
 
 use Neos\Flow\Core\Bootstrap;
 
@@ -40,6 +41,11 @@ class LoginController extends AbstractAuthenticationController
      * @Flow\InjectConfiguration(path="authFailedMessage.body")
      */
     protected $loginFailedBody;
+
+    /**
+     * @var FlashMessageContainer
+     */
+    protected $flashMessageContainer;
 
     /**
      * SkipCsrfProtection is needed here because we will have errors otherwise if we render multiple
@@ -94,6 +100,9 @@ class LoginController extends AbstractAuthenticationController
     {
         $this->emitAuthenticationFailure($this->controllerContext, $exception);
 
+        $this->flashMessageContainer = new FlashMessageContainer();
+
+        //TODO: This does not work yet. There is no error but it will not be displayed.
         $this->flashMessageContainer->addMessage(new Error($this->loginFailedBody,
             ($exception === null ? 1347016771 : $exception->getCode()), [], $this->loginFailedTitle));
     }
@@ -165,8 +174,11 @@ class LoginController extends AbstractAuthenticationController
     {
         $escapedUri = htmlentities($result, ENT_QUOTES, 'utf-8');
 
+
+        //TODO: Switch to ActionRequest. This does not work anymore.
         $response = $this->bootstrap->getActiveRequestHandler()->getHttpResponse(); /** @var  \Neos\Flow\Http\Response $response*/
 
+        //TODO: When switched to ActionRequest then you can make this in one line with ->setRedirectUri()
         $response->setHeader('Location', $escapedUri);
         $response->setHeader('Status', '303');
 

--- a/Classes/Domain/Validator/CustomPasswordDtoValidator.php
+++ b/Classes/Domain/Validator/CustomPasswordDtoValidator.php
@@ -41,6 +41,8 @@ class CustomPasswordDtoValidator extends AbstractValidator
      */
     protected function isValid($value)
     {
+        //TODO: result can't be resolved
+
         // Matching PW and PW confirmation
         if (!$value->arePasswordsEqual()) {
             $message = $this->translator->translateById('validations.password.matching', [], null, null, 'Main', 'Sandstorm.UserManagement');

--- a/Classes/Domain/Validator/CustomPasswordDtoValidator.php
+++ b/Classes/Domain/Validator/CustomPasswordDtoValidator.php
@@ -41,48 +41,48 @@ class CustomPasswordDtoValidator extends AbstractValidator
      */
     protected function isValid($value)
     {
-        //TODO: result can't be resolved. Something like $result = new result(); do not throw an error but don't give back the msg.
+        $result = $this->getResult();
 
         // Matching PW and PW confirmation
         if (!$value->arePasswordsEqual()) {
             $message = $this->translator->translateById('validations.password.matching', [], null, null, 'Main', 'Sandstorm.UserManagement');
-            $this->result->forProperty('password')->addError(new Error($message, 1464086581));
+            $result->forProperty('password')->addError(new Error($message, 1464086581));
         }
 
         // Min length
         if (!$value->isPasswordMinLength($this->passwordConstraints['minLength'])) {
             $message = $this->translator->translateById('validations.password.minlength', [$this->passwordConstraints['minLength']], null, null, 'Main', 'Sandstorm.UserManagement');
-            $this->result->forProperty('password')->addError(new Error($message, 1542220177));
+            $result->forProperty('password')->addError(new Error($message, 1542220177));
         }
 
         // Max length
         if (!$value->isPasswordMaxLength($this->passwordConstraints['maxLength'])) {
             $message = $this->translator->translateById('validations.password.maxlength', [$this->passwordConstraints['maxLength']], null, null, 'Main', 'Sandstorm.UserManagement');
-            $this->result->forProperty('password')->addError(new Error($message, 1542220177));
+            $result->forProperty('password')->addError(new Error($message, 1542220177));
         }
 
         // minNumberOfLowercaseLetters
         if (!$value->doesPasswordContainLowercaseLetters($this->passwordConstraints['minNumberOfLowercaseLetters'])) {
             $message = $this->translator->translateById('validations.password.lowercase', [$this->passwordConstraints['minNumberOfLowercaseLetters']], $this->passwordConstraints['minNumberOfLowercaseLetters'], null, 'Main', 'Sandstorm.UserManagement');
-            $this->result->forProperty('password')->addError(new Error($message, 1542220177));
+            $result->forProperty('password')->addError(new Error($message, 1542220177));
         }
 
         // minNumberOfUppercaseLetters
         if (!$value->doesPasswordContainUppercaseLetters($this->passwordConstraints['minNumberOfUppercaseLetters'])) {
             $message = $this->translator->translateById('validations.password.uppercase', [$this->passwordConstraints['minNumberOfUppercaseLetters']], $this->passwordConstraints['minNumberOfUppercaseLetters'], null, 'Main', 'Sandstorm.UserManagement');
-            $this->result->forProperty('password')->addError(new Error($message, 1542220177));
+            $result->forProperty('password')->addError(new Error($message, 1542220177));
         }
 
         // minNumberOfNumbers
         if (!$value->doesPasswordContainNumbers($this->passwordConstraints['minNumberOfNumbers'])) {
             $message = $this->translator->translateById('validations.password.numbers', [$this->passwordConstraints['minNumberOfNumbers']], $this->passwordConstraints['minNumberOfNumbers'], null, 'Main', 'Sandstorm.UserManagement');
-            $this->result->forProperty('password')->addError(new Error($message, 1542220177));
+            $result->forProperty('password')->addError(new Error($message, 1542220177));
         }
 
         // minNumberOfSpecialCharacters
         if (!$value->doesPasswordContainSpecialCharacters($this->passwordConstraints['minNumberOfSpecialCharacters'])) {
             $message = $this->translator->translateById('validations.password.special', [$this->passwordConstraints['minNumberOfSpecialCharacters']], $this->passwordConstraints['minNumberOfSpecialCharacters'], null, 'Main', 'Sandstorm.UserManagement');
-            $this->result->forProperty('password')->addError(new Error($message, 1542220177));
+            $result->forProperty('password')->addError(new Error($message, 1542220177));
         }
     }
 }

--- a/Classes/Domain/Validator/CustomPasswordDtoValidator.php
+++ b/Classes/Domain/Validator/CustomPasswordDtoValidator.php
@@ -41,7 +41,7 @@ class CustomPasswordDtoValidator extends AbstractValidator
      */
     protected function isValid($value)
     {
-        //TODO: result can't be resolved
+        //TODO: result can't be resolved. Something like $result = new result(); do not throw an error but don't give back the msg.
 
         // Matching PW and PW confirmation
         if (!$value->arePasswordsEqual()) {

--- a/Classes/ViewHelpers/IfAuthenticatedViewHelper.php
+++ b/Classes/ViewHelpers/IfAuthenticatedViewHelper.php
@@ -11,6 +11,17 @@ class IfAuthenticatedViewHelper extends AbstractConditionViewHelper
 {
 
     /**
+     * Initialize arguments
+     *
+     * @return void
+     * @api
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('authenticationProviderName', 'string', 'Use a different Authentication Provider than the default one', false,'Sandstorm.UserManagement:Login');
+    }
+
+    /**
      * Renders <f:then> child if any account is currently authenticated, otherwise renders <f:else> child.
      *
      * @param string $authenticationProviderName

--- a/Classes/ViewHelpers/IfAuthenticatedViewHelper.php
+++ b/Classes/ViewHelpers/IfAuthenticatedViewHelper.php
@@ -28,8 +28,9 @@ class IfAuthenticatedViewHelper extends AbstractConditionViewHelper
      * @return string the rendered string
      * @api
      */
-    public function render($authenticationProviderName = 'Sandstorm.UserManagement:Login')
+    public function render()
     {
+        $authenticationProviderName = $this->arguments['authenticationProviderName'];
         if (static::evaluateCondition($this->arguments, $this->renderingContext)) {
             return $this->renderThenChild();
         }

--- a/Resources/Private/Templates/Registration/Index.html
+++ b/Resources/Private/Templates/Registration/Index.html
@@ -17,19 +17,19 @@
         <fieldset>
           <label>
             E-Mail-Adresse
-            <f:form.textfield property="email" placeholder="test@example.com" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" type="email"/>
+            <f:form.textfield property="email" placeholder="test@example.com" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" type="email" required="true"/>
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.email'}"/>
           </label>
 
           <label>
             Passwort
-            <f:form.password placeholder="Ihr Passwort" property="passwordDto.password"/>
+            <f:form.password placeholder="Ihr Passwort" property="passwordDto.password" required="true"/>
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.passwordDto.password'}"/>
           </label>
 
           <label>
             Passwortbestätigung
-            <f:form.password placeholder="Passwort wiederholen" property="passwordDto.passwordConfirmation"/>
+            <f:form.password placeholder="Passwort wiederholen" property="passwordDto.passwordConfirmation" required="true"/>
           </label>
 
           <label>
@@ -40,7 +40,7 @@
 
           <label>
             Vorname
-            <f:form.textfield placeholder="Manfred" property="attributes.firstName"/>
+            <f:form.textfield placeholder="Manfred" property="attributes.firstName" required="true"/>
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.attributes.firstName'}"/>
           </label>
 


### PR DESCRIPTION
Neos 5.x / Flow 6.x has some breaking changes that also affect the plugin. I've already started to fix the problem, but I haven't managed to get the plugin to work 100%. 

Here is the [Upgrade Guide](https://docs.neos.io/cms/references/upgrade-instructions/upgrade-instructions-4-3-5-0)

Everything that do not work yet is marked with `TODO` in code

- [x] `IfAuthenticatedViewHelper` is not useable because of missing arguments. 
- [x]  Redirect after Logout does not work (caused by the switch to GuzzleHttp) - Need to work with ActionRequest now I guess.
- [x]  `flashMessageContainer` on Login does not work yet.
- [x] `CustomPasswordDtoValidator` does not work because it can't access `result`.


Feel free to edit/add everything that belongs to it.

**UPDATE**: Just tested everything and it seems to work with Neos 5 now!