### PR TITLE
I18N for Templates and more

### DIFF
--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -3,6 +3,7 @@ namespace Sandstorm\UserManagement\Controller;
 
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Message;
+use Neos\Flow\I18n\Translator;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Sandstorm\UserManagement\Domain\Service\RedirectTargetServiceInterface;
@@ -38,16 +39,56 @@ class LoginController extends AbstractAuthenticationController
     protected $uriFactory;
 
     /**
+     * @Flow\Inject
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
      * @var string
      * @Flow\InjectConfiguration(path="authFailedMessage.title")
      */
     protected $loginFailedTitle;
 
     /**
+     * @return string
+     */
+    protected function getLoginFailedTitle()
+    {
+        return $this->loginFailedTitle === 'i18n'
+            ? $this->translator->translateById(
+                'authFailedMessage.title',
+                [],
+                null,
+                null,
+                'Main',
+                'Sandstorm.UserManagement'
+            )
+            : $this->loginFailedTitle;
+    }
+
+    /**
      * @var string
      * @Flow\InjectConfiguration(path="authFailedMessage.body")
      */
     protected $loginFailedBody;
+
+    /**
+     * @return string
+     */
+    protected function getLoginFailedBody()
+    {
+        return $this->loginFailedBody === 'i18n'
+            ? $this->translator->translateById(
+                'authFailedMessage.body',
+                [],
+                null,
+                null,
+                'Main',
+                'Sandstorm.UserManagement'
+            )
+            : $this->loginFailedBody;
+    }
 
     /**
      * SkipCsrfProtection is needed here because we will have errors otherwise if we render multiple
@@ -101,7 +142,7 @@ class LoginController extends AbstractAuthenticationController
     protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
     {
         $this->emitAuthenticationFailure($this->controllerContext, $exception);
-        $this->addFlashMessage($this->loginFailedBody, $this->loginFailedTitle,Message::SEVERITY_ERROR, [], ($exception === null ? 1347016771 : $exception->getCode()));
+        $this->addFlashMessage($this->getLoginFailedBody(), $this->getLoginFailedTitle(),Message::SEVERITY_ERROR, [], ($exception === null ? 1347016771 : $exception->getCode()));
     }
 
     /**

--- a/Classes/Controller/RegistrationController.php
+++ b/Classes/Controller/RegistrationController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Sandstorm\UserManagement\Controller;
 
+use Neos\Flow\I18n\Translator;
 use Sandstorm\TemplateMailer\Domain\Service\EmailService;
 use Sandstorm\UserManagement\Domain\Model\RegistrationFlow;
 use Sandstorm\UserManagement\Domain\Repository\RegistrationFlowRepository;
@@ -33,10 +34,33 @@ class RegistrationController extends ActionController
     protected $emailService;
 
     /**
+     * @Flow\Inject
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
      * @var string
      * @Flow\InjectConfiguration(path="email.subjectActivation")
      */
     protected $subjectActivation;
+
+    /**
+     * @return string
+     */
+    protected function getSubjectActivation()
+    {
+        return $this->subjectActivation === 'i18n'
+            ? $this->translator->translateById(
+                'email.subjectActivation',
+                [],
+                null,
+                null,
+                'Main',
+                'Sandstorm.UserManagement'
+            )
+            : $this->subjectActivation;
+    }
 
 
     /**
@@ -69,7 +93,7 @@ class RegistrationController extends ActionController
 
         $this->emailService->sendTemplateEmail(
             'ActivationToken',
-            $this->subjectActivation,
+            $this->getSubjectActivation(),
             [$registrationFlow->getEmail()],
             [
                 'activationLink' => $activationLink,

--- a/Classes/Controller/ResetPasswordController.php
+++ b/Classes/Controller/ResetPasswordController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Sandstorm\UserManagement\Controller;
 
+use Neos\Flow\I18n\Translator;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Sandstorm\UserManagement\Domain\Model\ResetPasswordFlow;
 use Sandstorm\UserManagement\Domain\Repository\ResetPasswordFlowRepository;
@@ -40,11 +41,33 @@ class ResetPasswordController extends ActionController
     protected $emailService;
 
     /**
+     * @Flow\Inject
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
      * @var string
      * @Flow\InjectConfiguration(path="email.subjectResetPassword")
      */
     protected $subjectResetPassword;
 
+    /**
+     * @return string
+     */
+    protected function getSubjectResetPassword()
+    {
+        return $this->subjectResetPassword === 'i18n'
+            ? $this->translator->translateById(
+                'email.subjectResetPassword',
+                [],
+                null,
+                null,
+                'Main',
+                'Sandstorm.UserManagement'
+            )
+            : $this->subjectResetPassword;
+    }
 
     /**
      * @Flow\SkipCsrfProtection
@@ -88,7 +111,7 @@ class ResetPasswordController extends ActionController
 
             $this->emailService->sendTemplateEmail(
                 'ResetPasswordToken',
-                $this->subjectResetPassword,
+                $this->getSubjectResetPassword(),
                 [$resetPasswordFlow->getEmail()],
                 [
                     'resetPasswordLink' => $resetPasswordLink,

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,10 +5,14 @@ Sandstorm:
     # Validity timespan for the token used to reset passwords.
     resetPasswordTokenTimeout: '4 hours'
     # The message that appears if a user could not be logged in.
+    # Set the value to 'i18n' to enable translations
+    # using 'authFailedMessage.title and authFailedMessage.body as id.
     authFailedMessage:
       title: 'Login nicht möglich'
       body: 'Sie haben ungültige Zugangsdaten eingegeben. Bitte versuchen Sie es noch einmal.'
     # Email settings
+    # Set the value to 'i18n' to enable translations
+    # using 'email.subjectActivation' and 'email.subjectResetPassword' as id.
     email:
       subjectActivation: 'Please confirm your account'
       # Subject line for the password reset email

--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ Sandstorm:
     rolesForNewUsers: []
 ```
 
+### I18N
+It is possible to use i18n for the messages configured in the settings. Simply by setting the values to 'i18n'.
+```
+Sandstorm:
+  UserManagement:
+    authFailedMessage:
+      title: 'i18n'
+      body: 'i18n'
+    email:
+      subjectActivation: 'i18n'
+      subjectResetPassword: 'i18n'
+```
+
 ## Additional Settings for usage in Neos
 You should switch the implementation of the Redirect and User Creation Services to the Neos services. Add this to your `Objects.yaml`:
 ```
@@ -366,7 +379,6 @@ Feel free to submit issues/PRs :)
 
 # 6. TODOs
 
-* I18N for Templates.
 * More Tests.
 
 # 7. FAQ

--- a/Resources/Private/Partials/LogoutForm.html
+++ b/Resources/Private/Partials/LogoutForm.html
@@ -5,9 +5,9 @@
       lang="en">
 
 <f:section name="Logout">
-  <p>Sie sind eingeloggt als <strong>{account.accountIdentifier}</strong>.</p>
+  <p><f:translate id="logout.loggedAs" arguments="{0: '{account.accountIdentifier}'}"></f:translate></p>
   <f:form action="logout" method="post" additionalAttributes="{role:'form'}">
-    <f:form.submit value="Ausloggen" class="button primary" />
+    <f:form.submit value="{f:translate(id: 'logout')}" class="button primary" />
   </f:form>
 </f:section>
 

--- a/Resources/Private/Templates/Login/Login.html
+++ b/Resources/Private/Templates/Login/Login.html
@@ -17,12 +17,12 @@
     <f:else>
       <f:form action="authenticate" method="post">
         <fieldset>
-          <input placeholder="test@example.com" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" type="email" autofocus>
-          <input placeholder="Passwort" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]" type="password" value="">
-          <input type="submit" value="Login" class="button large primary" />
+          <input placeholder="{f:translate(id: 'email')}" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" type="email" autofocus>
+          <input placeholder="{f:translate(id: 'password')}" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]" type="password" value="">
+          <input type="submit" value="{f:translate(id: 'login')}" class="button large primary" />
         </fieldset>
       </f:form>
-      <f:link.action action="index" controller="ResetPassword">Passwort vergessen?</f:link.action>
+      <f:link.action action="index" controller="ResetPassword"><f:translate id="passwordForgotten"></f:translate></f:link.action>
     </f:else>
   </usermanagement:ifAuthenticated>
 </f:section>

--- a/Resources/Private/Templates/Registration/ActivateAccount.html
+++ b/Resources/Private/Templates/Registration/ActivateAccount.html
@@ -18,28 +18,28 @@
 
   <f:if condition="{tokenNotFound}">
     <div class="callout alert">
-      <p>Der Aktivierungslink war nicht gültig.
-        <f:link.action action="index" controller="Registration" package="Sandstorm.UserManagement">Bitte registrieren Sie sich erneut.</f:link.action>
+      <p><f:translate id="activation.linkNotValid"></f:translate>
+        <f:link.action action="index" controller="Registration" package="Sandstorm.UserManagement"><f:translate id="activation.registerAgain"></f:translate></f:link.action>
       </p>
     </div>
   </f:if>
 
   <f:if condition="{tokenTimeout}">
     <div class="callout alert">
-      <p>Der Aktivierungslink ist nicht mehr gültig.
-        <f:link.action action="index" controller="Registration" package="Sandstorm.UserManagement">Bitte registrieren Sie sich erneut.</f:link.action>
+      <p><f:translate id="activation.linkExpired"></f:translate>
+        <f:link.action action="index" controller="Registration" package="Sandstorm.UserManagement"><f:translate id="activation.registerAgain"></f:translate></f:link.action>
       </p>
     </div>
   </f:if>
 
   <f:if condition="{success}">
     <div class="callout success">
-      <p>Sie sind nun aktiviert und können sich auf unserer Website anmelden.
+      <p><f:translate id="activation.successMessage"></f:translate>
       </p>
     </div>
     <!-- This can cause issues in the Neos use case, as then the Login Form will be displayed in the registration plugin's subcontext, which might
     not make sense. Therefore, deactivated for the time being. Feel free to uncomment in your own template. -->
-    <!--<f:link.action controller="Login" action="login" package="Sandstorm.UserManagement" class="button large primary">Zum Login</f:link.action>-->
+    <!--<f:link.action controller="Login" action="login" package="Sandstorm.UserManagement" class="button large primary"><f:translate id="toTheLogin"></f:translate></f:link.action>-->
   </f:if>
 
 </f:section>

--- a/Resources/Private/Templates/Registration/Index.html
+++ b/Resources/Private/Templates/Registration/Index.html
@@ -16,7 +16,7 @@
       <f:form action="register" method="post" objectName="registrationFlow">
         <fieldset>
           <label>
-            <f:translate id="email"></f:translate>
+            <f:translate id="emailAddress"></f:translate>
             <f:form.textfield property="email" placeholder="test@example.com" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" type="email" required="true"/>
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.email'}"/>
           </label>

--- a/Resources/Private/Templates/Registration/Index.html
+++ b/Resources/Private/Templates/Registration/Index.html
@@ -16,41 +16,41 @@
       <f:form action="register" method="post" objectName="registrationFlow">
         <fieldset>
           <label>
-            E-Mail-Adresse
+            <f:translate id="email"></f:translate>
             <f:form.textfield property="email" placeholder="test@example.com" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" type="email" required="true"/>
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.email'}"/>
           </label>
 
           <label>
-            Passwort
-            <f:form.password placeholder="Ihr Passwort" property="passwordDto.password" required="true"/>
+            <f:translate id="password"></f:translate>
+            <f:form.password placeholder="{f:translate(id: 'yourPassword')}" property="passwordDto.password" required="true"/>
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.passwordDto.password'}"/>
           </label>
 
           <label>
-            Passwortbestätigung
-            <f:form.password placeholder="Passwort wiederholen" property="passwordDto.passwordConfirmation" required="true"/>
+            <f:translate id="registration.confirmPassword"></f:translate>
+            <f:form.password placeholder="{f:translate(id: 'registration.repeatPassword')}" property="passwordDto.passwordConfirmation" required="true"/>
           </label>
 
           <label>
-            Anrede
-            <f:form.select options="{'m': 'Herr', 'f': 'Frau'}" property="attributes.salutation" />
+            <f:translate id="registration.salutation"></f:translate>
+            <f:form.select options="{'m': 'Mr.', 'f': 'Ms.'}" translate="{by: 'id', prefix: 'registration.salutationOptions.'}" property="attributes.salutation" />
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.attributes.salutation'}"/>
           </label>
 
           <label>
-            Vorname
+            <f:translate id="firstName"></f:translate>
             <f:form.textfield placeholder="Manfred" property="attributes.firstName" required="true"/>
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.attributes.firstName'}"/>
           </label>
 
           <label>
-            Nachname
+            <f:translate id="lastName"></f:translate>
             <f:form.textfield placeholder="Mustermann" property="attributes.lastName"/>
             <f:render partial="FormErrors" section="ValidationResults" arguments="{for: 'registrationFlow.attributes.lastName'}"/>
           </label>
 
-          <input type="submit" value="Registrieren" class="button large primary"/>
+          <input type="submit" value="{f:translate(id: 'registration.register')}" class="button large primary"/>
         </fieldset>
       </f:form>
     </f:else>

--- a/Resources/Private/Templates/Registration/Register.html
+++ b/Resources/Private/Templates/Registration/Register.html
@@ -9,7 +9,7 @@
 
 <f:section name="Content">
   <div class="callout success">
-    <p>Wir haben eine E-Mail zur Bestätigung der Registrierung an <strong>{registrationFlow.email}</strong> gesendet. Bitte folgen Sie der Anleitung in der E-Mail, um die Registrierung zu bestätigen.</p>
+    <p><f:translate id="registration.confirmationEmailSent" arguments="{registrationFlow.email}"></f:translate></p>
   </div>
 </f:section>
 

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="de" datatype="plaintext">
         <body>
-            <trans-unit id="email">
-                <source>Email</source>
-                <target>E-mail</target>
+            <trans-unit id="emailAddress">
+                <source>Email address</source>
+                <target>E-mail-Adresse</target>
             </trans-unit>
             <trans-unit id="login">
                 <source>Login</source>

--- a/Resources/Private/Translations/de/Main.xlf
+++ b/Resources/Private/Translations/de/Main.xlf
@@ -86,6 +86,22 @@
                 <source>Your account is has been activated. You can now log in to our website.</source>
                 <target>Ihr Konto ist aktiviert worden. Sie können sich jetzt auf unserer Website einloggen.</target>
             </trans-unit>
+            <trans-unit id="authFailedMessage.title">
+                <source>Unable to login.</source>
+                <target>Login nicht möglich</target>
+            </trans-unit>
+            <trans-unit id="authFailedMessage.body">
+                <source>You have entered invalid access data. Please try again.</source>
+                <target>Sie haben ungültige Zugangsdaten eingegeben. Bitte versuchen Sie es noch einmal.</target>
+            </trans-unit>
+            <trans-unit id="email.subjectActivation">
+                <source>Please confirm your account</source>
+                <target>Bitte bestätigen Sie Ihr Konto</target>
+            </trans-unit>
+            <trans-unit id="email.subjectResetPassword">
+                <source>Password reset</source>
+                <target>Passwort zurücksetzen</target>
+            </trans-unit>
             <trans-unit id="validations.registrationflow.email" xml:space="preserve">
                 <source>Email address {0} is already in use!</source>
                 <target>Die E-Mail-Adresse {0} wird bereits verwendet!</target>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -2,6 +2,69 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file original="" product-name="Sandstorm.UserManagement" source-language="en" datatype="plaintext">
         <body>
+            <trans-unit id="email">
+                <source>Email</source>
+            </trans-unit>
+            <trans-unit id="login">
+                <source>Login</source>
+            </trans-unit>
+            <trans-unit id="toTheLogin">
+                <source>To the login</source>
+            </trans-unit>
+            <trans-unit id="password">
+                <source>Password</source>
+            </trans-unit>
+            <trans-unit id="yourPassword">
+                <source>Your password</source>
+            </trans-unit>
+            <trans-unit id="passwordForgotten">
+                <source>Password forgotten</source>
+            </trans-unit>
+            <trans-unit id="logout">
+                <source>Logout</source>
+            </trans-unit>
+            <trans-unit id="logout.loggedAs">
+                <source>You are logged in as {0}.</source>
+            </trans-unit>
+            <trans-unit id="firstName">
+                <source>First name</source>
+            </trans-unit>
+            <trans-unit id="lastName">
+                <source>Last name</source>
+            </trans-unit>
+            <trans-unit id="registration.confirmPassword">
+                <source>Confirm password</source>
+            </trans-unit>
+            <trans-unit id="registration.repeatPassword">
+                <source>Repeat password</source>
+            </trans-unit>
+            <trans-unit id="registration.salutation">
+                <source>Salutation</source>
+            </trans-unit>
+            <trans-unit id="registration.salutationOptions.f">
+                <source>Ms.</source>
+            </trans-unit>
+            <trans-unit id="registration.salutationOptions.m">
+                <source>Mr.</source>
+            </trans-unit>
+            <trans-unit id="registration.register">
+                <source>Register</source>
+            </trans-unit>
+            <trans-unit id="registration.confirmationEmailSent">
+                <source>We have sent an email to confirm the registration to <strong>%s</strong>. Please follow the instructions in the email to confirm the registration.</source>
+            </trans-unit>
+            <trans-unit id="activation.linkNotValid">
+                <source>The activation link was not valid.</source>
+            </trans-unit>
+            <trans-unit id="activation.registerAgain">
+                <source>Please register again.</source>
+            </trans-unit>
+            <trans-unit id="activation.linkExpired">
+                <source>The activation link has expired.</source>
+            </trans-unit>
+            <trans-unit id="activation.successMessage">
+                <source>Your account is has been activated. You can now log in to our website.</source>
+            </trans-unit>
             <trans-unit id="validations.registrationflow.email" xml:space="preserve">
                 <source>Email address {0} is already in use!</source>
             </trans-unit>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -65,6 +65,18 @@
             <trans-unit id="activation.successMessage">
                 <source>Your account is has been activated. You can now log in to our website.</source>
             </trans-unit>
+            <trans-unit id="authFailedMessage.title">
+                <source>Unable to login.</source>
+            </trans-unit>
+            <trans-unit id="authFailedMessage.body">
+                <source>You have entered invalid access data. Please try again.</source>
+            </trans-unit>
+            <trans-unit id="email.subjectActivation">
+                <source>Please confirm your account</source>
+            </trans-unit>
+            <trans-unit id="email.subjectResetPassword">
+                <source>Password reset</source>
+            </trans-unit>
             <trans-unit id="validations.registrationflow.email" xml:space="preserve">
                 <source>Email address {0} is already in use!</source>
             </trans-unit>

--- a/Resources/Private/Translations/en/Main.xlf
+++ b/Resources/Private/Translations/en/Main.xlf
@@ -2,8 +2,8 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file original="" product-name="Sandstorm.UserManagement" source-language="en" datatype="plaintext">
         <body>
-            <trans-unit id="email">
-                <source>Email</source>
+            <trans-unit id="emailAddress">
+                <source>Email address</source>
             </trans-unit>
             <trans-unit id="login">
                 <source>Login</source>

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -1,145 +1,145 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="de" datatype="plaintext">
+    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
         <body>
             <trans-unit id="email">
                 <source>Email</source>
-                <target>E-mail</target>
+                <target>Email</target>
             </trans-unit>
             <trans-unit id="login">
                 <source>Login</source>
-                <target>Sich anmelden</target>
+                <target>Se connecter</target>
             </trans-unit>
             <trans-unit id="toTheLogin">
                 <source>To the login</source>
-                <target>Zum Login</target>
+                <target>Vers le login</target>
             </trans-unit>
             <trans-unit id="password">
                 <source>Password</source>
-                <target>Passwort</target>
+                <target>Mot de passe</target>
             </trans-unit>
             <trans-unit id="yourPassword">
                 <source>Your password</source>
-                <target>Ihr Passwort</target>
+                <target>Votre mot de passe</target>
             </trans-unit>
             <trans-unit id="passwordForgotten">
                 <source>Password forgotten</source>
-                <target>Passwort vergessen</target>
+                <target>Mot de passe oublié</target>
             </trans-unit>
             <trans-unit id="logout">
                 <source>Logout</source>
-                <target>Ausloggen</target>
+                <target>Se déconnecter</target>
             </trans-unit>
             <trans-unit id="logout.loggedAs">
                 <source>You are logged in as {0}.</source>
-                <target>Sie sind eingeloggt als {0}.</target>
+                <target>Vous êtes connecté en tant que {0}.</target>
             </trans-unit>
             <trans-unit id="firstName">
                 <source>First name</source>
-                <target>Vorname</target>
+                <target>Prénom</target>
             </trans-unit>
             <trans-unit id="lastName">
                 <source>Last name</source>
-                <target>Nachname</target>
+                <target>Nom de famille</target>
             </trans-unit>
             <trans-unit id="registration.confirmPassword">
                 <source>Confirm password</source>
-                <target>Passwort bestätigen</target>
+                <target>Confirmation du mot de passe</target>
             </trans-unit>
             <trans-unit id="registration.repeatPassword">
                 <source>Repeat password</source>
-                <target>Passwort wiederholen</target>
+                <target>Répéter le mot de passe</target>
             </trans-unit>
             <trans-unit id="registration.salutation">
                 <source>Salutation</source>
-                <target>Anrede</target>
+                <target>Salutation</target>
             </trans-unit>
             <trans-unit id="registration.salutationOptions.f">
                 <source>Ms.</source>
-                <target>Frau</target>
+                <target>Madame</target>
             </trans-unit>
             <trans-unit id="registration.salutationOptions.m">
                 <source>Mr.</source>
-                <target>Herr</target>
+                <target>Monsieur</target>
             </trans-unit>
             <trans-unit id="registration.register">
                 <source>Register</source>
-                <target>Registrieren</target>
+                <target>S'inscrire</target>
             </trans-unit>
             <trans-unit id="registration.confirmationEmailSent">
-                <source>We have sent an email to confirm the registration to <strong>%s</strong>. Please follow the instructions in the email to confirm the registration.</source>
-                <target>Wir haben eine E-Mail zur Bestätigung der Registrierung an <strong>%s</strong> gesendet. Bitte folgen Sie der Anleitung in der E-Mail, um die Registrierung zu bestätigen.</target>
+                <source>We have sent an email to confirm the registration to {0}. Please follow the instructions in the email to confirm the registration.</source>
+                <target>Nous avons envoyé un email à {0} pour confirmer l'enregistrement. Veuillez suivre les instructions contenues dans l'e-mail pour confirmer l'inscription.</target>
             </trans-unit>
             <trans-unit id="activation.linkNotValid">
                 <source>The activation link was not valid.</source>
-                <target>Der Aktivierungslink war nicht gültig.</target>
+                <target>Le lien d'activation n'était pas valide.</target>
             </trans-unit>
             <trans-unit id="activation.registerAgain">
                 <source>Please register again.</source>
-                <target>Bitte registrieren Sie sich erneut.</target>
+                <target>Veuillez vous réinscrire.</target>
             </trans-unit>
             <trans-unit id="activation.linkExpired">
                 <source>The activation link has expired.</source>
-                <target>Der Aktivierungslink ist nicht mehr gültig.</target>
+                <target>Le lien d'activation a expiré.</target>
             </trans-unit>
             <trans-unit id="activation.successMessage">
                 <source>Your account is has been activated. You can now log in to our website.</source>
-                <target>Ihr Konto ist aktiviert worden. Sie können sich jetzt auf unserer Website einloggen.</target>
+                <target>Votre compte a été activé. Vous pouvez maintenant vous connecter à notre site web.</target>
             </trans-unit>
             <trans-unit id="validations.registrationflow.email" xml:space="preserve">
                 <source>Email address {0} is already in use!</source>
-                <target>Die E-Mail-Adresse {0} wird bereits verwendet!</target>
+                <target>L'adresse e-mail {0} est déjà utilisée !</target>
             </trans-unit>
             <trans-unit id="validations.password.matching" xml:space="preserve">
                 <source>Your passwords do not match.</source>
-                <target>Die Passwörter stimmen nicht überein.</target>
+                <target>Vos mots de passe ne correspondent pas.</target>
             </trans-unit>
             <trans-unit id="validations.password.minlength" xml:space="preserve">
                 <source>Your password needs to be at least {0} characters long.</source>
-                <target>Das Passwort muss mindestens {0} Zeichen lang sein.</target>
+                <target>Votre mot de passe doit comporter au moins {0} caractères.</target>
             </trans-unit>
             <trans-unit id="validations.password.maxlength" xml:space="preserve">
                 <source>Your password must be at most {0} characters long.</source>
-                <target>Das Passwort darf höchstens {0} Zeichen lang sein.</target>
+                <target>Votre mot de passe doit comporter au maximum {0} caractères.</target>
             </trans-unit>
             <group id="validations.password.lowercase" restype="x-gettext-plurals">
                 <trans-unit id="validations.password.lowercase[0]">
                     <source>Your password needs to contain at least {0} lowercase letter.</source>
-                    <target>Das Passwort muss mindestens {0} Kleinbuchstaben enthalten.</target>
+                    <target>Votre mot de passe doit contenir au moins {0} lettre minuscule.</target>
                 </trans-unit>
                 <trans-unit id="validations.password.lowercase[1]">
                     <source>Your password needs to contain at least {0} lowercase letters.</source>
-                    <target>Das Passwort muss mindestens {0} Kleinbuchstaben enthalten.</target>
+                    <target>Votre mot de passe doit contenir au moins {0} lettres minuscules.</target>
             </trans-unit>
             </group>
             <group id="validations.password.uppercase" restype="x-gettext-plurals">
                 <trans-unit id="validations.password.uppercase[0]">
                     <source>Your password needs to contain at least {0} uppercase letter.</source>
-                    <target>Das Passwort muss mindestens {0} Großbuchstaben enthalten.</target>
+                    <target>Votre mot de passe doit contenir au moins {0} lettre majuscule.</target>
                 </trans-unit>
                 <trans-unit id="validations.password.uppercase[1]">
                     <source>Your password needs to contain at least {0} uppercase letters.</source>
-                    <target>Das Passwort muss mindestens {0} Großbuchstaben enthalten.</target>
+                    <target>Votre mot de passe doit contenir au moins {0} lettres majuscules.</target>
                 </trans-unit>
             </group>
             <group id="validations.password.numbers" restype="x-gettext-plurals">
                 <trans-unit id="validations.password.numbers[0]">
                     <source>Your password needs to contain at least {0} number.</source>
-                    <target>Das Passwort muss mindestens {0} Zahl enthalten.</target>
+                    <target>Votre mot de passe doit contenir au moins {0} chiffre.</target>
                 </trans-unit>
                 <trans-unit id="validations.password.numbers[1]">
                     <source>Your password needs to contain at least {0} numbers.</source>
-                    <target>Das Passwort muss mindestens {0} Zahlen enthalten.</target>
+                    <target>Votre mot de passe doit contenir au moins {0} chiffres.</target>
                 </trans-unit>
             </group>
             <group id="validations.password.special" restype="x-gettext-plurals">
                 <trans-unit id="validations.password.special[0]">
                     <source>Your password needs to contain at least {0} special character.</source>
-                    <target>Das Passwort muss mindestens {0} Sonderzeichen (z.B. %!=) enthalten.</target>
+                    <target>Votre mot de passe doit contenir au moins {0} caractère spécial.</target>
                 </trans-unit>
                 <trans-unit id="validations.password.special[1]">
                     <source>Your password needs to contain at least {0} special characters.</source>
-                    <target>Das Passwort muss mindestens {0} Sonderzeichen (z.B. %!=) enthalten.</target>
+                    <target>Votre mot de passe doit contenir au moins {0} caractères spéciaux.</target>
                 </trans-unit>
             </group>
         </body>

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -86,6 +86,22 @@
                 <source>Your account is has been activated. You can now log in to our website.</source>
                 <target>Votre compte a été activé. Vous pouvez maintenant vous connecter à notre site web.</target>
             </trans-unit>
+            <trans-unit id="authFailedMessage.title">
+                <source>Unable to login.</source>
+                <target>Impossible de se connecter.</target>
+            </trans-unit>
+            <trans-unit id="authFailedMessage.body">
+                <source>You have entered invalid access data. Please try again.</source>
+                <target>Vous avez saisi des données d'accès invalides. Veuillez réessayer.</target>
+            </trans-unit>
+            <trans-unit id="email.subjectActivation">
+                <source>Please confirm your account</source>
+                <target>Veuillez confirmer votre compte</target>
+            </trans-unit>
+            <trans-unit id="email.subjectResetPassword">
+                <source>Password reset</source>
+                <target>Réinitialisation du mot de passe</target>
+            </trans-unit>
             <trans-unit id="validations.registrationflow.email" xml:space="preserve">
                 <source>Email address {0} is already in use!</source>
                 <target>L'adresse e-mail {0} est déjà utilisée !</target>

--- a/Resources/Private/Translations/fr/Main.xlf
+++ b/Resources/Private/Translations/fr/Main.xlf
@@ -2,9 +2,9 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
         <body>
-            <trans-unit id="email">
-                <source>Email</source>
-                <target>Email</target>
+            <trans-unit id="emailAddress">
+                <source>Email address</source>
+                <target>Adresse email</target>
             </trans-unit>
             <trans-unit id="login">
                 <source>Login</source>

--- a/Resources/Private/Translations/fr/NodeTypes/LoginForm.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/LoginForm.xlf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
+        <body>
+            <trans-unit id="ui.label" xml:space="preserve">
+                <source>Login Form</source>
+                <target>Formulaire de connexion</target>
+            </trans-unit>
+            <trans-unit id="groups.pluginSettings" xml:space="preserve">
+                <source>Login Settings</source>
+                <target>Réglages de connexion</target>
+            </trans-unit>
+            <trans-unit id="properties.redirectAfterLogin" xml:space="preserve">
+                <source>Redirect after Login</source>
+                <target>Redirection après connexion</target>
+            </trans-unit>
+            <trans-unit id="properties.redirectAfterLogout" xml:space="preserve">
+                <source>Redirect after Logout</source>
+                <target>Redirection après déconnexion</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Profile.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Profile.xlf
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
+        <body>
+            <trans-unit id="ui.label" xml:space="preserve">
+                <source>User Profile</source>
+                <target>Profil utilisateur</target>
+            </trans-unit>
+            <trans-unit id="groups.pluginSettings" xml:space="preserve">
+                <source>User Profile Settings</source>
+                <target>Réglage du profil utilisateur</target>
+            </trans-unit>
+            <trans-unit id="properties.showPersonalInformation" xml:space="preserve">
+                <source>Show Personal Information</source>
+                <target>Afficher les informations personnelles</target>
+            </trans-unit>
+            <trans-unit id="properties.showAccountInformation" xml:space="preserve">
+                <source>Show Account Information</source>
+                <target>Afficher les informations du compte</target>
+            </trans-unit>
+            <trans-unit id="properties.enableNewPassword" xml:space="preserve">
+                <source>Enable Setting of a new Password</source>
+                <target>Afficher la création d'un nouveau mot de passe</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Registration.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Registration.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
+        <body>
+            <trans-unit id="ui.label" xml:space="preserve">
+                <source>Registration Form</source>
+                <target>Formulaire d'inscription</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/fr/Partials/Profile/AccountData.xlf
+++ b/Resources/Private/Translations/fr/Partials/Profile/AccountData.xlf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
+        <body>
+            <trans-unit id="accountData.email" xml:space="preserve">
+                <source>E-mail address:</source>
+                <target>Adresse email:</target>
+            </trans-unit>
+            <trans-unit id="accountData.roles" xml:space="preserve">
+                <source>Role(s):</source>
+                <target>Rôle(s):</target>
+            </trans-unit>
+            <trans-unit id="accountData.createdOn" xml:space="preserve">
+                <source>Created on:</source>
+                <target>Créé le:</target>
+            </trans-unit>
+            <trans-unit id="accountData.dateFormat" xml:space="preserve">
+                <source>Y-m-d</source>
+                <target>d.m.Y</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/fr/Partials/Profile/PasswordForm.xlf
+++ b/Resources/Private/Translations/fr/Partials/Profile/PasswordForm.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
+        <body>
+            <trans-unit id="passwordForm.newPassword" xml:space="preserve">
+                <source>New Password</source>
+                <target>Nouveau mot de passe</target>
+            </trans-unit>
+            <trans-unit id="passwordForm.confirmNewPassword" xml:space="preserve">
+                <source>Repeat new password</source>
+                <target>Répéter le nouveau mot de passe</target>
+            </trans-unit>
+            <trans-unit id="passwordForm.changePassword" xml:space="preserve">
+                <source>Change password</source>
+                <target>Modifier le mot de passe</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/fr/Partials/Profile/PersonalForm.xlf
+++ b/Resources/Private/Translations/fr/Partials/Profile/PersonalForm.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
+        <body>
+            <trans-unit id="personalForm.firstName" xml:space="preserve">
+                <source>First name</source>
+                <target>Prénom</target>
+            </trans-unit>
+            <trans-unit id="personalForm.lastName" xml:space="preserve">
+                <source>Last name</source>
+                <target>Nom de famille</target>
+            </trans-unit>
+            <trans-unit id="personalForm.changeData" xml:space="preserve">
+                <source>Change personal data</source>
+                <target>Modifier les informations personnelles</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/fr/Templates/Partials/Profile.xlf
+++ b/Resources/Private/Translations/fr/Templates/Partials/Profile.xlf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file original="" product-name="Sandstorm.UserManagement" source-language="en" target-language="fr" datatype="plaintext">
+        <body>
+            <trans-unit id="profile.title" xml:space="preserve">
+                <source>Profile Settings</source>
+                <target>Réglages du profil</target>
+            </trans-unit>
+            <trans-unit id="profile.personal" xml:space="preserve">
+                <source>User</source>
+                <target>Utilisateur</target>
+            </trans-unit>
+            <trans-unit id="profile.account" xml:space="preserve">
+                <source>Account</source>
+                <target>Compte</target>
+            </trans-unit>
+            <trans-unit id="profile.password" xml:space="preserve">
+                <source>Password</source>
+                <target>Mot de passe</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
Hi there,

Here is a Pull Request concerning i18n.

I made i18n for Templates but also the ability to translate the four messages that could be set in the `Configuration/Settings.yaml` file. All the translations for the Templates (and Settings) have been written in the `Main.xlf` files.

I also added french translations and updated the `README.md` file.

One thing I did not know how to do was to make the email address bold again after translation (see `Resources/Private/Partials/LogoutForm.html` file).

I remain available if you have any questions and/or remarks.

Best regards,
Chrys