### PR TITLE
[BUGFIX] Fix translation arguments type and wrong translation id

### DIFF
--- a/Resources/Private/Templates/Login/Login.html
+++ b/Resources/Private/Templates/Login/Login.html
@@ -17,7 +17,7 @@
     <f:else>
       <f:form action="authenticate" method="post">
         <fieldset>
-          <input placeholder="{f:translate(id: 'email')}" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" type="email" autofocus>
+          <input placeholder="{f:translate(id: 'emailAddress')}" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" type="email" autofocus>
           <input placeholder="{f:translate(id: 'password')}" name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]" type="password" value="">
           <input type="submit" value="{f:translate(id: 'login')}" class="button large primary" />
         </fieldset>

--- a/Resources/Private/Templates/Registration/Register.html
+++ b/Resources/Private/Templates/Registration/Register.html
@@ -9,7 +9,7 @@
 
 <f:section name="Content">
   <div class="callout success">
-    <p><f:translate id="registration.confirmationEmailSent" arguments="{registrationFlow.email}"></f:translate></p>
+    <p><f:translate id="registration.confirmationEmailSent" arguments="{0: '{registrationFlow.email}'}"></f:translate></p>
   </div>
 </f:section>
 


### PR DESCRIPTION
Hi,

I fixed two bugs I made in [my last PR](https://github.com/sandstorm/UserManagement/pull/54#).

- [Small bugfix] Calling translation with the correct `id`. See `Resources/Private/Templates/Login/Login.html`
- [Important bugfix] Changing `arguments` value of the translation to be of type array. See `Resources/Private/Templates/Registration/Register.html`

Sorry for the inconvenience and lack of attention!

Best regards,
Chrys