### PR TITLE
Find email with username and unit tests in workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,20 +8,18 @@ on:
 
 jobs:
   unit-tests:
-    name: Unit Tests (PHP ${{ matrix.php }})
+    name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          # no matrix across 8.2-8.4 here: these are plain PHP unit tests with no
+          # version-sensitive logic, so one version is enough signal for the added CI cost
+          php-version: '8.4'
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    name: Unit Tests (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4']
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-plugins --prefer-dist
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,4 +28,4 @@ jobs:
         run: composer install --no-plugins --prefer-dist
 
       - name: Run unit tests
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit Tests/Unit

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@ vendor/
 # composer
 composer.lock
 
+# phpunit
+.phpunit.result.cache
+phpunit.xml.dist
+
 # IDEs
 .idea/

--- a/Classes/Controller/ResetPasswordController.php
+++ b/Classes/Controller/ResetPasswordController.php
@@ -5,6 +5,7 @@ use Neos\Flow\I18n\Translator;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Sandstorm\UserManagement\Domain\Model\ResetPasswordFlow;
 use Sandstorm\UserManagement\Domain\Repository\ResetPasswordFlowRepository;
+use Sandstorm\UserManagement\Domain\Service\FindEmailAddressForUserServiceInterface;
 use Sandstorm\UserManagement\Domain\Service\UserCreationServiceInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
@@ -39,6 +40,12 @@ class ResetPasswordController extends ActionController
      * @var \Sandstorm\TemplateMailer\Domain\Service\EmailService
      */
     protected $emailService;
+
+    /**
+     * @Flow\Inject
+     * @var FindEmailAddressForUserServiceInterface
+     */
+    protected $findEmailAddressForUserService;
 
     /**
      * @Flow\Inject
@@ -104,28 +111,32 @@ class ResetPasswordController extends ActionController
                 }
             }
 
-            // Send out a confirmation mail
-            $resetPasswordLink = $this->uriBuilder->reset()->setCreateAbsoluteUri(true)->uriFor(
-                'insertNewPassword',
-                ['token' => $resetPasswordFlow->getResetPasswordToken()],
-                'ResetPassword');
+            $receiverMail = $this->findEmailAddressForUserService->getEmailAddressByAccount($account);
 
-            $this->emailService->sendTemplateEmail(
-                'ResetPasswordToken',
-                $this->getSubjectResetPassword(),
-                [$resetPasswordFlow->getEmail()],
-                [
-                    'resetPasswordLink' => $resetPasswordLink,
-                    'resetPasswordFlow' => $resetPasswordFlow
-                ],
-                'sandstorm_usermanagement_sender_email',
-                [], // cc
-                [], // bcc
-                [], // attachments
-                'sandstorm_usermanagement_replyTo_email'
-            );
+            if ($receiverMail !== null) {
+                // Send out a confirmation mail
+                $resetPasswordLink = $this->uriBuilder->reset()->setCreateAbsoluteUri(true)->uriFor(
+                    'insertNewPassword',
+                    ['token' => $resetPasswordFlow->getResetPasswordToken()],
+                    'ResetPassword');
 
-            $this->resetPasswordFlowRepository->add($resetPasswordFlow);
+                $this->emailService->sendTemplateEmail(
+                    'ResetPasswordToken',
+                    $this->getSubjectResetPassword(),
+                    [$receiverMail],
+                    [
+                        'resetPasswordLink' => $resetPasswordLink,
+                        'resetPasswordFlow' => $resetPasswordFlow
+                    ],
+                    'sandstorm_usermanagement_sender_email',
+                    [], // cc
+                    [], // bcc
+                    [], // attachments
+                    'sandstorm_usermanagement_replyTo_email'
+                );
+
+                $this->resetPasswordFlowRepository->add($resetPasswordFlow);
+            }
         }
 
 

--- a/Classes/Domain/Model/ResetPasswordFlow.php
+++ b/Classes/Domain/Model/ResetPasswordFlow.php
@@ -16,7 +16,6 @@ class ResetPasswordFlow
     /**
      * @var string
      * @Flow\Validate(type="NotEmpty")
-     * @Flow\Validate(type="EmailAddress")
      */
     protected $email;
 

--- a/Classes/Domain/Service/FindEmailAddressForUserByAccountIdentifierService.php
+++ b/Classes/Domain/Service/FindEmailAddressForUserByAccountIdentifierService.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Sandstorm\UserManagement\Domain\Service;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Security\Account;
+
+/**
+ * @api
+ * @Flow\Scope("singleton")
+ */
+class FindEmailAddressForUserByAccountIdentifierService implements FindEmailAddressForUserServiceInterface
+{
+    /**
+     * @param Account $account
+     * @return string|null
+     */
+    public function getEmailAddressByAccount(Account $account)
+    {
+        return $account->getAccountIdentifier();
+    }
+}

--- a/Classes/Domain/Service/FindEmailAddressForUserServiceInterface.php
+++ b/Classes/Domain/Service/FindEmailAddressForUserServiceInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Sandstorm\UserManagement\Domain\Service;
+
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Security\Account;
+
+/**
+ * @api
+ */
+interface FindEmailAddressForUserServiceInterface
+{
+    /**
+     * @param Account $account
+     * @return string|null
+     */
+    public function getEmailAddressByAccount(Account $account);
+}

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -3,3 +3,5 @@ Sandstorm\UserManagement\Domain\Service\RedirectTargetServiceInterface:
   className: 'Sandstorm\UserManagement\Domain\Service\Flow\FlowRedirectTargetService'
 Sandstorm\UserManagement\Domain\Service\UserCreationServiceInterface:
   className: 'Sandstorm\UserManagement\Domain\Service\Flow\FlowUserCreationService'
+Sandstorm\UserManagement\Domain\Service\FindEmailAddressForUserServiceInterface:
+  className: 'Sandstorm\UserManagement\Domain\Service\FindEmailAddressForUserByAccountIdentifierService'

--- a/README.md
+++ b/README.md
@@ -287,6 +287,16 @@ Sandstorm\UserManagement\Domain\Service\UserCreationServiceInterface:
   className: 'Your\Package\Domain\Service\YourCustomUserCreationService'
 ```
 
+## Customizing how the reset-password e-mail address is resolved
+By default, the "forgot password" flow sends the reset link to the account identifier the user entered (i.e. username
+and e-mail address are assumed to be identical). If your application decouples usernames from e-mail addresses, you
+can override how the recipient address is resolved by implementing `FindEmailAddressForUserServiceInterface` and
+wiring it up via `Objects.yaml`:
+```YAML
+Sandstorm\UserManagement\Domain\Service\FindEmailAddressForUserServiceInterface:
+  className: 'Your\Package\Domain\Service\YourCustomFindEmailAddressForUserService'
+```
+
 ## Hooking into the login/logout process
 The UserManagement package emits three signals during the login and logout process, into which you can hook
 using Flows [Signals and Slots](http://flowframework.readthedocs.io/en/stable/TheDefinitiveGuide/PartIII/SignalsAndSlots.html)
@@ -370,8 +380,11 @@ class RegistrationFlowValidationService implements RegistrationFlowValidationSer
 ```
 
 # 4. Running Tests
-Run all unit tests with:
-`./bin/phpunit -c ./Build/BuildEssentials/PhpUnit/UnitTests.xml Packages/Application/Sandstorm.UserManagement/Tests/Unit`
+Unit tests run standalone in this package, no Flow distribution required:
+```
+composer install
+vendor/bin/phpunit
+```
 
 To run E2E tests, see [E2E Test Readme](Tests/E2E/README.md)
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ class RegistrationFlowValidationService implements RegistrationFlowValidationSer
 Unit tests run standalone in this package, no Flow distribution required:
 ```
 composer install
-vendor/bin/phpunit
+vendor/bin/phpunit Tests/Unit
 ```
 
 To run E2E tests, see [E2E Test Readme](Tests/E2E/README.md)

--- a/Tests/Unit/Domain/PasswordDtoTest.php
+++ b/Tests/Unit/Domain/PasswordDtoTest.php
@@ -5,19 +5,16 @@ use Neos\Flow\Tests\UnitTestCase;
 use Sandstorm\UserManagement\Domain\Model\PasswordDto;
 
 /**
- * Testcase for the package class
+ * Testcase for PasswordDto
  *
  */
-class PackageTest extends UnitTestCase
+class PasswordDtoTest extends UnitTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
     }
 
-    /**
-     * @test
-     */
-    public function equalPasswordsAreEqual()
+    public function testEqualPasswordsAreEqual()
     {
         $passwordDto = new PasswordDto();
         $passwordDto->setPassword('foobar');
@@ -26,10 +23,7 @@ class PackageTest extends UnitTestCase
         $this->assertTrue($passwordDto->arePasswordsEqual());
     }
 
-    /**
-     * @test
-     */
-    public function inequalPasswordsAreNotEqual()
+    public function testInequalPasswordsAreNotEqual()
     {
         $passwordDto = new PasswordDto();
         $passwordDto->setPassword('FOOBAR');
@@ -38,10 +32,7 @@ class PackageTest extends UnitTestCase
         $this->assertFalse($passwordDto->arePasswordsEqual());
     }
 
-    /**
-     * @test
-     */
-    public function passwordMinLength()
+    public function testPasswordMinLength()
     {
         $passwordDto = new PasswordDto();
         $passwordDto->setPassword('6chars');
@@ -51,10 +42,7 @@ class PackageTest extends UnitTestCase
         $this->assertFalse($passwordDto->isPasswordMinLength(7));
     }
 
-    /**
-     * @test
-     */
-    public function passwordMaxLength()
+    public function testPasswordMaxLength()
     {
         $passwordDto = new PasswordDto();
         $passwordDto->setPassword('6chars');
@@ -64,10 +52,7 @@ class PackageTest extends UnitTestCase
         $this->assertFalse($passwordDto->isPasswordMaxLength(5));
     }
 
-    /**
-     * @test
-     */
-    public function passwordContainsLowercaseLetters()
+    public function testPasswordContainsLowercaseLetters()
     {
         $passwordDto = new PasswordDto();
         $passwordDto->setPassword('4loweRCASELETTERS');
@@ -78,10 +63,7 @@ class PackageTest extends UnitTestCase
         $this->assertFalse($passwordDto->doesPasswordContainLowercaseLetters(5));
     }
 
-    /**
-     * @test
-     */
-    public function passwordContainsUppercaseLetters()
+    public function testPasswordContainsUppercaseLetters()
     {
         $passwordDto = new PasswordDto();
         $passwordDto->setPassword('4UPPErcaseletters');
@@ -92,10 +74,7 @@ class PackageTest extends UnitTestCase
         $this->assertFalse($passwordDto->doesPasswordContainUppercaseLetters(5));
     }
 
-    /**
-     * @test
-     */
-    public function passwordContainsNumbers()
+    public function testPasswordContainsNumbers()
     {
         $passwordDto = new PasswordDto();
         $passwordDto->setPassword('fournumbers1234');
@@ -106,10 +85,7 @@ class PackageTest extends UnitTestCase
         $this->assertFalse($passwordDto->doesPasswordContainNumbers(5));
     }
 
-    /**
-     * @test
-     */
-    public function passwordContainsSpecialCharacters()
+    public function testPasswordContainsSpecialCharacters()
     {
         $passwordDto = new PasswordDto();
         $passwordDto->setPassword('4specialCHARS!"%$');

--- a/Tests/Unit/Domain/Service/FindEmailAddressForUserByAccountIdentifierServiceTest.php
+++ b/Tests/Unit/Domain/Service/FindEmailAddressForUserByAccountIdentifierServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Sandstorm\UserManagement\Tests\Unit\Domain\Service;
+
+use Neos\Flow\Security\Account;
+use Neos\Flow\Tests\UnitTestCase;
+use Sandstorm\UserManagement\Domain\Service\FindEmailAddressForUserByAccountIdentifierService;
+
+/**
+ * Testcase for the FindEmailAddressForUserByAccountIdentifierService
+ *
+ */
+class FindEmailAddressForUserByAccountIdentifierServiceTest extends UnitTestCase
+{
+    public function testReturnsTheAccountIdentifierWhenItIsAnEmailAddress()
+    {
+        $account = new Account();
+        $account->setAccountIdentifier('user@example.com');
+
+        $service = new FindEmailAddressForUserByAccountIdentifierService();
+
+        $this->assertSame('user@example.com', $service->getEmailAddressByAccount($account));
+    }
+
+    public function testReturnsTheAccountIdentifierUnchangedWhenItIsAPlainUsername()
+    {
+        $account = new Account();
+        $account->setAccountIdentifier('someuser');
+
+        $service = new FindEmailAddressForUserByAccountIdentifierService();
+
+        $this->assertSame('someuser', $service->getEmailAddressByAccount($account));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,18 @@
         "neos/flow": "^8.3 || ^9.0",
         "sandstorm/templatemailer": "^3.0.1 || dev-master"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^13.0"
+    },
     "autoload": {
         "psr-4": {
             "Sandstorm\\UserManagement\\": "Classes"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Sandstorm\\UserManagement\\Tests\\": "Tests",
+            "Neos\\Flow\\Tests\\": "vendor/neos/flow/Tests"
         }
     }
 }


### PR DESCRIPTION
Adds a pluggable way to resolve the reset-password notification address, plus a standalone unit-test setup with CI coverage.

- New FindEmailAddressForUserServiceInterface — lets consumers resolve the reset-password e-mail from the account instead of assuming account identifier == e-mail address. Default implementation preserves current behavior, wired via Objects.yaml.
- ResetPasswordController resolves the recipient through this interface and only sends/persists when it returns a non-null address.
- ResetPasswordFlow::$email no longer requires e-mail format, so a plain username can be submitted.
- Unit tests run standalone now (composer install && vendor/bin/phpunit), no Flow distribution needed. Bumped phpunit to ^13.0.
- New unit-tests.yml CI workflow (PHP 8.2–8.4).